### PR TITLE
Update requirements4.txt -- deleted usb creator

### DIFF
--- a/requirements4.txt
+++ b/requirements4.txt
@@ -67,7 +67,6 @@ six==1.14.0
 texttable==1.6.2
 toml==0.10.2
 urllib3==1.25.8
-usb-creator==0.3.7
 virtualenv==20.7.0
 wadllib==1.3.3
 websocket-client==0.53.0


### PR DESCRIPTION
The requirement file contained a lot of muck that was not "required". Usb creator version required could not be found so I deleted it